### PR TITLE
Fix the integration of battery status and autonomy status components into the existing code base

### DIFF
--- a/src/app/autonomy-status/autonomy-status.component.css
+++ b/src/app/autonomy-status/autonomy-status.component.css
@@ -1,19 +1,17 @@
 .autonomy-status-window{
-    width: fit-content;
+    width: 100%;
+    height: 100%;
 }
 
 .autonomy-status {
     display: flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid black;
     padding: 5px;
-    min-width: 181px; /* To avoid resizing */
 }
 
 .autonomy-status-window-title {
-    border: 1px solid black;
-    border-bottom: none;
+    border-bottom: 2px solid royalblue;
     text-align: center;
     padding: 5px;
 }

--- a/src/app/battery/battery-info/battery-info.component.css
+++ b/src/app/battery/battery-info/battery-info.component.css
@@ -1,9 +1,10 @@
 .battery-info {
-    border: 1px solid black;
+    border: 1px solid royalblue;
+    min-width: 112px;
 }
 
 .battery-side {
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid royalblue;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/app/battery/battery-status-window/battery-status-window.component.css
+++ b/src/app/battery/battery-status-window/battery-status-window.component.css
@@ -1,5 +1,5 @@
 .battery-status-window{
-    width: fit-content;
+    width: 100%
 }
 
 .battery-info-wrapper {
@@ -7,13 +7,12 @@
     flex-direction: row;
     gap: 5px;
     flex-wrap: wrap;
-    border: 1px solid black;
+
     padding: 5px;
 }
 
 .battery-status-window-title {
-    border: 1px solid black;
-    border-bottom: none;
+    border-bottom: 2px solid royalblue;
     text-align: center;
     padding: 5px;
 }

--- a/src/app/battery/battery-status-window/battery-status-window.component.html
+++ b/src/app/battery/battery-status-window/battery-status-window.component.html
@@ -4,5 +4,4 @@
         <app-battery-info [side]="'L'" [voltage]="leftBatteryVoltage"></app-battery-info>
         <app-battery-info [side]="'R'" [voltage]="rightBatteryVoltage"></app-battery-info>
     </div>
-    <app-low-battery-warning [display]="displayWarning()" [warningMessage]="warningMessage()"></app-low-battery-warning>
 </div>

--- a/src/app/battery/battery-status-window/battery-status-window.component.ts
+++ b/src/app/battery/battery-status-window/battery-status-window.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { BatteryInfoComponent } from '../battery-info/battery-info.component';
 import { RosService } from '../../services/ros.service';
 import { LowBatteryWarningComponent } from '../low-battery-warning/low-battery-warning.component';
+import { WarningMessageService } from '../../services/warning-message.service';
 
 @Component({
   selector: 'app-battery-status-window',
@@ -15,40 +16,41 @@ export class BatteryStatusWindowComponent implements OnInit {
   rightBatteryVoltage: number;
   
 
-  constructor(private rosService: RosService) {
+  constructor(private rosService: RosService, private warningService: WarningMessageService) {
     this.leftBatteryVoltage = 0; // Initial value
     this.rightBatteryVoltage = 0; // Initial value
   }
 
   ngOnInit(): void {
-    // Subscribe to the left battery voltage topic
+    // Subscribe to the left battery voltage topic, update the value and check if a warning needs to be displayed
     this.rosService.subscribeToLeftBatteryVoltage((data: number) => {
       this.leftBatteryVoltage = data;
+      this.checkWarning();
     });
 
-    // Subscribe to the right battery voltage topic
+    // Subscribe to the right battery voltage topic, update the value and check if a warning needs to be displayed
     this.rosService.subscribeToRightBatteryVoltage((data: number) => {
       this.rightBatteryVoltage = data;
+      this.checkWarning();
     });
   }
 
-  displayWarning(): string {
-    if (this.leftBatteryVoltage <= 13.5 || this.rightBatteryVoltage <= 13.5) {
-      return 'flex'
+  // Check for warnings and call displayWarning with appropriate arguments
+  checkWarning(): void {
+    if (this.leftBatteryVoltage <= 13.5 && this.rightBatteryVoltage <= 13.5) {
+      this.displayWarning('Both batteries are low!', true);
+    } else if (this.leftBatteryVoltage <= 13.5 ) {
+      this.displayWarning('Battery L is low!', true);
+    } else if (this.rightBatteryVoltage <= 13.5 ) {
+      this.displayWarning('Battery R is low!' , true);    
     } else {
-      return 'none'
+      this.displayWarning('', false);
     }
   }
 
-  warningMessage(): string {
-    if (this.leftBatteryVoltage <= 13.5 && this.rightBatteryVoltage <= 13.5) {
-      return 'Both batteries are low!'
-    } else if (this.leftBatteryVoltage <= 13.5 ) {
-      return 'Battery L is low!'
-    } else if (this.rightBatteryVoltage <= 13.5 ) {
-      return 'Battery R is low!'     
-    } else {
-      return ''
-    }
+  // Sets the given warning message and warning component visibility
+  displayWarning(warningMessage : string, warningVisibility : boolean): void {
+    this.warningService.setWarningMessage(warningMessage);
+    this.warningService.setWarningVisibility(warningVisibility);
   }
 }

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -12,10 +12,10 @@
 <app-resizable *ngIf="camerasVisible" [component]="VideoClientComponent" [width]="400" [height]="400" [left]="0" [top]="400">
 </app-resizable>
 
-<app-resizable *ngIf="batteryStatusVisible" [component]="BatteryStatusWindowComponent" [width]="400" [height]="400" [left]="400" [top]="0">
+<app-resizable *ngIf="batteryStatusVisible" [component]="BatteryStatusWindowComponent" [width]="243" [height]="115" [left]="400" [top]="0" [minWidth]="243" [minHeight]="115">
 </app-resizable>
 
-<app-resizable *ngIf="autonomyStatusVisible" [component]="AutonomyStatusComponent" [width]="400" [height]="400" [left]="400" [top]="400" [minWidth]="160" [minHeight]="60">
+<app-resizable *ngIf="autonomyStatusVisible" [component]="AutonomyStatusComponent" [width]="160" [height]="60" [left]="400" [top]="400" [minWidth]="160" [minHeight]="60">
 </app-resizable>
 
 <app-warning>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -15,7 +15,7 @@
 <app-resizable *ngIf="batteryStatusVisible" [component]="BatteryStatusWindowComponent" [width]="400" [height]="400" [left]="400" [top]="0">
 </app-resizable>
 
-<app-resizable *ngIf="autonomyStatusVisible" [component]="AutonomyStatusComponent" [width]="400" [height]="400" [left]="400" [top]="400">
+<app-resizable *ngIf="autonomyStatusVisible" [component]="AutonomyStatusComponent" [width]="400" [height]="400" [left]="400" [top]="400" [minWidth]="160" [minHeight]="60">
 </app-resizable>
 
 <app-warning>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -17,3 +17,6 @@
 
 <app-resizable *ngIf="autonomyStatusVisible" [component]="AutonomyStatusComponent" [width]="400" [height]="400" [left]="400" [top]="400">
 </app-resizable>
+
+<app-warning>
+</app-warning>

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -6,6 +6,7 @@ import {VideoClientComponent} from "../video-client/video-client.component";
 import {ResizableComponent} from "../resizable/resizable.component";
 import { BatteryStatusWindowComponent } from '../battery/battery-status-window/battery-status-window.component';
 import { AutonomyStatusComponent } from '../autonomy-status/autonomy-status.component';
+import { WarningComponent } from '../warning/warning.component';
 
 @Component({
   selector: 'app-dashboard',
@@ -18,6 +19,7 @@ import { AutonomyStatusComponent } from '../autonomy-status/autonomy-status.comp
     ResizableComponent,
     BatteryStatusWindowComponent,
     AutonomyStatusComponent,
+    WarningComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.css'

--- a/src/app/resizable/resizable.component.ts
+++ b/src/app/resizable/resizable.component.ts
@@ -24,6 +24,8 @@ export class ResizableComponent{
   @Input('height') public height: number = 150;
   @Input('left') public left: number = 100;
   @Input('top') public top: number = 100;
+  @Input('minWidth') public minWidth: number = 0;
+  @Input('minHeight') public minHeight: number = 0;
 
   @ViewChild("box") public box: ElementRef | undefined;
   private boxPosition: { left: number; top: number; } | undefined;
@@ -65,8 +67,8 @@ export class ResizableComponent{
   }
   private resize(){
     if(this.resizeCondMeet()){
-      this.width = Number(this.mouse!!.x > this.boxPosition!!.left) ? this.mouse!!.x - this.boxPosition!!.left : 0;
-      this.height = Number(this.mouse!!.y > this.boxPosition!!.top) ? this.mouse!!.y - this.boxPosition!!.top : 0;
+      this.width = Math.max(Number(this.mouse!!.x > this.boxPosition!!.left) ? this.mouse!!.x - this.boxPosition!!.left : 0, this.minWidth);
+      this.height = Math.max(Number(this.mouse!!.y > this.boxPosition!!.top) ? this.mouse!!.y - this.boxPosition!!.top : 0, this.minHeight);
     }
   }
   private resizeCondMeet(){

--- a/src/app/services/warning-message.service.ts
+++ b/src/app/services/warning-message.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class WarningMessageService {
+  private warningMessage: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  private warningVisibility: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  constructor() { }
+
+  getWarningMessage(): Observable<string> {
+    return this.warningMessage.asObservable();
+  }
+
+  getWarningVisibility(): Observable<boolean> {
+    return this.warningVisibility.asObservable();
+  }
+
+  setWarningMessage(message : string) {
+    this.warningMessage.next(message);
+  }
+
+  setWarningVisibility(visibility : boolean) {
+    this.warningVisibility.next(visibility)
+  }
+}

--- a/src/app/warning/warning.component.css
+++ b/src/app/warning/warning.component.css
@@ -1,0 +1,15 @@
+.warning {
+    position: absolute;
+    width: 500px;
+    height: 100px;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    border: 5px solid red;
+    background-color: rgba(255, 0, 0, 0.411);
+    display: flex; 
+    align-items: center;
+    justify-content: center;
+    font-size: 30px;
+    font-weight: bold;
+}

--- a/src/app/warning/warning.component.html
+++ b/src/app/warning/warning.component.html
@@ -1,0 +1,1 @@
+<div *ngIf="warningVisibility" class="warning">{{ warningMessage }}</div> <!-- TODO: Add appropriate warning symbol later -->

--- a/src/app/warning/warning.component.spec.ts
+++ b/src/app/warning/warning.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WarningComponent } from './warning.component';
+
+describe('WarningComponent', () => {
+  let component: WarningComponent;
+  let fixture: ComponentFixture<WarningComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WarningComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(WarningComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/warning/warning.component.ts
+++ b/src/app/warning/warning.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input } from '@angular/core';
+import { WarningMessageService } from '../services/warning-message.service';
+import { NgIf } from '@angular/common';
+
+
+@Component({
+  selector: 'app-warning',
+  standalone: true,
+  imports: [NgIf],
+  templateUrl: './warning.component.html',
+  styleUrl: './warning.component.css'
+})
+export class WarningComponent {
+  warningMessage: string = '';
+  warningVisibility: boolean = false;
+
+  constructor(private warningService: WarningMessageService) { }
+
+  ngOnInit(): void {
+    this.warningService.getWarningMessage().subscribe(message => {
+      this.warningMessage = message;
+    });
+    
+    this.warningService.getWarningVisibility().subscribe(visibility => {
+      this.warningVisibility = visibility;
+    });
+  }
+}


### PR DESCRIPTION
- Created a warning component and warning service that can be reused for arm error feedback
- Fixed the issue where the warning message appeared in the middle of the resizable component instead of the middle of the screen
- Added an optional min height and min width property to the resizable component that can prevent inner components from collapsing