### PR TITLE
Add Aruco Detection (without images going through ROS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cmake-build-debug/
 node_modules
 .angular
 space-env/
+marker_*.png

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake-build-debug/
 .vscode
 node_modules
 .angular
+space-env/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ cmake-build-debug/
 node_modules
 .angular
 space-env/
+venv/
 marker_*.png

--- a/README.md
+++ b/README.md
@@ -16,15 +16,35 @@ Run `python3 -m venv ./space-env` from the robotics-orin folder.
 So you use it automatically, add the source to your ~/.bashrc: `echo "source ${PWD}/space-env/bin/activate" >> ~/.bashrc`
 
 #### Setting up ros2_aruco
+##### Short version
+Run these commands:
+- `pip install transforms3d`
+- Find where your python packages are installed (eg run the above command again) and source it in `~/.bashrc`. This line should
+**look like** the following: `export PYTHONPATH="/home/marc/Programming/robotics-orin/space-env/lib/python3.10/site-packages:$PYTHONPATH"`
+- `sudo apt install ffmpeg v4l2loopback-dkms v4l2loopback-utils v4l-utils`
+
+##### Long version
+
 To get this working, you may see the following error:
 ```
 Installing the transforms3d library by hand required. Please run
         sudo pip3 install transforms3d
 ```
 Run this command (in my case without the sudo and with pip) and it should work.
-Adding to PYTHONPATH is likely necessary. You will add a command like the following: 
+Adding to PYTHONPATH is likely necessary. You will add a command like the following to `~/.bashrc`: 
 `export PYTHONPATH="/home/marc/Programming/robotics-orin/space-env/lib/python3.10/site-packages:$PYTHONPATH"`
 
 Another thing to consider is that while python3-opencv (installed with apt, from rosdep) works with
 this package, it also works with opencv-python (installed through pip). There is a version difference,
 which is why there are lines such as `if cv2.__version__ < "4.7.0":` in the source.
+
+In addition, to allow the camera used for aruco detection to also be streamed, v4l2loopback must be configured
+and ffmpeg must be present. Install the following: `v4l2loopback-dkms`, `v4l2loopback-utils`, `v4l-utils`, and `ffmpeg`.
+
+If you have secure boot enabled, there will be additional setup involved (requiring a reboot). These packages might be added to `package.xml` 
+at some point, but it will need to be added to rosdep, which takes a little while.
+
+To allow simultaneous streaming on another process, set the `camera_index` and `camera_destination_index` params in the launch file.
+They correspond to which index in `/dev/video` to use. If camera_destination_index is set (to a value which is not -1), it will
+(attempt) to stream the camera from the source to the destination location (in `/dev/video`). Now, any other process can
+load the camera from the destination index.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ Run `python3 -m venv ./space-env` from the robotics-orin folder.
 So you use it automatically, add the source to your ~/.bashrc: `echo "source ${PWD}/space-env/bin/activate" >> ~/.bashrc`
 
 #### Setting up ros2_aruco
+
 ##### Short version
 Run these commands:
 - `pip install transforms3d`
 - Find where your python packages are installed (eg run the above command again) and source it in `~/.bashrc`. This line should
 **look like** the following: `export PYTHONPATH="/home/marc/Programming/robotics-orin/space-env/lib/python3.10/site-packages:$PYTHONPATH"`
-- `sudo apt install ffmpeg v4l2loopback-dkms v4l2loopback-utils v4l-utils`
+- If need to duplicate video: `sudo apt install ffmpeg v4l2loopback-dkms v4l2loopback-utils v4l-utils`
 
 ##### Long version
-
 To get this working, you may see the following error:
 ```
 Installing the transforms3d library by hand required. Please run

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The code in this repo was built around ROS Humble. First [install that](https://
 Then, from this folder:
 - I recommend you setup a [Python venv](https://docs.python.org/3/library/venv.html). See steps below.
 - Install rosdep, colcon, catkin, and pip (if not already) (`sudo apt install python3-colcon-common-extensions catkin_pkg python3-pip python3-rosdep2`)
-- Update rosdep (`rosdep update`)
+- Init and update rosdep (`sudo rosdep init && rosdep update`)
 - Run rosdep so it installs packages: `rosdep install --from-paths src --ignore-src -r -y`. Enter your password when prompted.
 - Install misc python deps (`pip install -r requirements.txt`)
 - Install JetsonGPIO [from GitHub](https://github.com/pjueon/JetsonGPIO/blob/master/docs/installation_guide.md). This must be 
@@ -24,3 +24,7 @@ Installing the transforms3d library by hand required. Please run
 Run this command (in my case without the sudo and with pip) and it should work.
 Adding to PYTHONPATH is likely necessary. You will add a command like the following: 
 `export PYTHONPATH="/home/marc/Programming/robotics-orin/space-env/lib/python3.10/site-packages:$PYTHONPATH"`
+
+Another thing to consider is that while python3-opencv (installed with apt, from rosdep) works with
+this package, it also works with opencv-python (installed through pip). There is a version difference,
+which is why there are lines such as `if cv2.__version__ < "4.7.0":` in the source.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+### Setup
+The code in this repo was built around ROS Humble. First [install that](https://docs.ros.org/en/humble/Installation.html).
+Then, from this folder:
+- I recommend you setup a [Python venv](https://docs.python.org/3/library/venv.html). See steps below.
+- Install rosdep, colcon, catkin, and pip (if not already) (`sudo apt install python3-colcon-common-extensions catkin_pkg python3-pip python3-rosdep2`)
+- Update rosdep (`rosdep update`)
+- Run rosdep so it installs packages: `rosdep install --from-paths src --ignore-src -r -y`. Enter your password when prompted.
+- Install misc python deps (`pip install -r requirements.txt`)
+- Install JetsonGPIO [from GitHub](https://github.com/pjueon/JetsonGPIO/blob/master/docs/installation_guide.md). This must be 
+manually installed. The default options will work.
+- Build: `colcon build --symlink-install --packages-skip usb_cam` (usb_cam can only compile on the Jetson, no easy workaround for it).
+
+#### Setup venv
+Run `python3 -m venv ./space-env` from the robotics-orin folder.
+
+So you use it automatically, add the source to your ~/.bashrc: `echo "source ${PWD}/space-env/bin/activate" >> ~/.bashrc`
+
+#### Setting up ros2_aruco
+To get this working, you may see the following error:
+```
+Installing the transforms3d library by hand required. Please run
+        sudo pip3 install transforms3d
+```
+Run this command (in my case without the sudo and with pip) and it should work.
+Adding to PYTHONPATH is likely necessary. You will add a command like the following: 
+`export PYTHONPATH="/home/marc/Programming/robotics-orin/space-env/lib/python3.10/site-packages:$PYTHONPATH"`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+empy==3.3.4
+catkin_pkg
+lark
+transforms3d

--- a/src/ros2_aruco/README.md
+++ b/src/ros2_aruco/README.md
@@ -12,10 +12,6 @@ pip3 install opencv-contrib-python transforms3d
 
 This node locates Aruco AR markers in images and publishes their ids and poses.
 
-Subscriptions:
-* `/camera/image_raw` (`sensor_msgs.msg.Image`)
-* `/camera/camera_info` (`sensor_msgs.msg.CameraInfo`)
-
 Published Topics:
 * `/aruco_poses` (`geometry_msgs.msg.PoseArray`) - Poses of all detected markers (suitable for rviz visualization)
 * `/aruco_markers` (`ros2_aruco_interfaces.msg.ArucoMarkers`) - Provides an array of all poses along with the corresponding marker ids
@@ -23,9 +19,11 @@ Published Topics:
 Parameters:
 * `marker_size` - size of the markers in meters (default .0625)
 * `aruco_dictionary_id` - dictionary that was used to generate markers (default `DICT_5X5_250`)
-* `image_topic` - image topic to subscribe to (default `/camera/image_raw`)
-* `camera_info_topic` - Camera info topic to subscribe to (default `/camera/camera_info`)
-* `camera_frame` - Camera optical frame to use (default to the frame id provided by the camera info message.)
+* `poll_delay_seconds` - how many seconds to wait between captures
+* `camera_index` - which camera index to open (0 corresponds to /dev/video0)
+* `camera_destination_index` - If present, will attempt to use v4l2loopback 
+                                to allow another process to access the camera.
+                                Needs ffmpeg and v4l2loopback-dev installed.
 
 ## Running Marker Detection
 

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -1,6 +1,6 @@
 /aruco_node:
   ros__parameters:
     marker_size: 0.055
-    aruco_dictionary_id: DICT_4x4_250
-    image_topic: /image_raw
-    camera_info_topic: /camera_info
+    aruco_dictionary_id: "DICT_5X5_250"
+    camera_index: 0
+    camera_destination_index: 10

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -1,6 +1,7 @@
 /aruco_node:
   ros__parameters:
+    poll_delay_seconds: 0.1
     marker_size: 0.055
     aruco_dictionary_id: "DICT_5X5_250"
     camera_index: 0
-    camera_destination_index: 10
+    # camera_destination_index: 10

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -1,7 +1,40 @@
 /aruco_node:
   ros__parameters:
     poll_delay_seconds: 0.1
-    marker_size: 0.055
+    marker_size: 0.050
     aruco_dictionary_id: "DICT_5X5_250"
-    camera_index: 0
+    camera_index: 2
     # camera_destination_index: 10
+    # Data comes from the C920 in the lab (on the gripper), calibrated with an 8x6 grid.
+    camera_matrix: [1431.3944 ,    0.     ,  890.65546,
+                    0.     , 1433.52778,  497.59295,
+                    0.     ,    0.     ,    1.     ]
+    distortion_coefficients: [0.058807, -0.181086, 0.002435, -0.003756, 0.000000]
+
+# This was the complete set of calibration data:
+# image_width: 1920
+# image_height: 1080
+# camera_name: narrow_stereo
+# camera_matrix:
+#   rows: 3
+#   cols: 3
+#   data: [1431.3944 ,    0.     ,  890.65546,
+#             0.     , 1433.52778,  497.59295,
+#             0.     ,    0.     ,    1.     ]
+# distortion_model: plumb_bob
+# distortion_coefficients:
+#   rows: 1
+#   cols: 5
+#   data: [0.058807, -0.181086, 0.002435, -0.003756, 0.000000]
+# rectification_matrix:
+#   rows: 3
+#   cols: 3
+#   data: [1., 0., 0.,
+#          0., 1., 0.,
+#          0., 0., 1.]
+# projection_matrix:
+#   rows: 3
+#   cols: 4
+#   data: [1408.47852,    0.     ,  873.88624,    0.     ,
+#             0.     , 1441.61267,  498.62912,    0.     ,
+#             0.     ,    0.     ,    1.     ,    0.     ]

--- a/src/ros2_aruco/ros2_aruco/package.xml
+++ b/src/ros2_aruco/ros2_aruco/package.xml
@@ -13,6 +13,7 @@
   <test_depend>python3-pytest</test_depend>
 
   <depend>tf_transformations</depend>
+  <depend>arcuo_opencv</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/src/ros2_aruco/ros2_aruco/package.xml
+++ b/src/ros2_aruco/ros2_aruco/package.xml
@@ -12,6 +12,8 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
+  <depend>tf_transformations</depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
@@ -16,6 +16,17 @@ class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
     pass
 
 
+def addWhiteBorder(image, borderSize):
+    newSize = (image.shape[0] + borderSize * 2, image.shape[1] + borderSize * 2)
+
+    imageWithBorder = np.zeros(newSize, dtype=image.dtype)
+    imageWithBorder += 255
+
+    imageWithBorder[borderSize:-borderSize, borderSize:-borderSize] = image
+
+    return imageWithBorder
+
+
 def main():
     parser = argparse.ArgumentParser(formatter_class=CustomFormatter,
                                      description="Generate a .png image of a specified maker.")
@@ -23,6 +34,9 @@ def main():
                         help='Marker id to generate')
     parser.add_argument('--size', default=200, type=int,
                         help='Side length in pixels')
+    parser.add_argument('--border', default=20, type=int,
+                        help='White border size in pixels')
+    
     dict_options = [s for s in dir(cv2.aruco) if s.startswith("DICT")]
     option_str = ", ".join(dict_options)
     dict_help = "Dictionary to use. Valid options include: {}".format(option_str)
@@ -32,10 +46,13 @@ def main():
     args = parser.parse_args()
 
     dictionary_id = cv2.aruco.__getattribute__(args.dictionary)
-    dictionary = cv2.aruco.Dictionary_get(dictionary_id)
+    dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
     image = np.zeros((args.size, args.size), dtype=np.uint8)
-    image = cv2.aruco.drawMarker(dictionary, args.id, args.size, image, 1)
+    image = cv2.aruco.generateImageMarker(dictionary, args.id, args.size, image, 1)
+    image = addWhiteBorder(image, args.border)
+
     cv2.imwrite("marker_{:04d}.png".format(args.id), image)
+
 
 
 if __name__ == "__main__":

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
@@ -48,7 +48,12 @@ def main():
     dictionary_id = cv2.aruco.__getattribute__(args.dictionary)
     dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
     image = np.zeros((args.size, args.size), dtype=np.uint8)
-    image = cv2.aruco.generateImageMarker(dictionary, args.id, args.size, image, 1)
+
+    if cv2.__version__ < "4.7.0":
+        image = cv2.aruco.drawMarker(dictionary, args.id, args.size, image, 1)
+    else:
+        image = cv2.aruco.generateImageMarker(dictionary, args.id, args.size, image, 1)
+
     image = addWhiteBorder(image, args.border)
 
     cv2.imwrite("marker_{:04d}.png".format(args.id), image)

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_generate_marker.py
@@ -17,10 +17,19 @@ class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
 
 
 def addWhiteBorder(image, borderSize):
+    """Add a white border of the given number of pixels around the image.
+
+    Parameters:
+    image  (np.array, type np.uint8, 2D): black and white image
+    borderSize: Number of pixels to add around each edge of the image
+
+    Returns:
+    np.array: image with border
+    """
+
     newSize = (image.shape[0] + borderSize * 2, image.shape[1] + borderSize * 2)
 
-    imageWithBorder = np.zeros(newSize, dtype=image.dtype)
-    imageWithBorder += 255
+    imageWithBorder = np.full(newSize, 255, dtype=image.dtype)
 
     imageWithBorder[borderSize:-borderSize, borderSize:-borderSize] = image
 

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
@@ -118,12 +118,12 @@ class ArucoNode(rclpy.node.Node):
         self.video_capture = cv2.VideoCapture(camera_index)
 
         if cv2.__version__ < "4.7.0":
-            self.get_logger().error("Opencv python must be at least version 4.7.0!")
-            return
-        
-        aruco_dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
-        parameters = cv2.aruco.DetectorParameters()
-        self.detector = cv2.aruco.ArucoDetector(aruco_dictionary, parameters)
+            self.aruco_dictionary = cv2.aruco.Dictionary_get(dictionary_id)
+            self.aruco_parameters = cv2.aruco.DetectorParameters_create()
+        else:
+            aruco_dictionary = cv2.aruco.getPredefinedDictionary(dictionary_id)
+            parameters = cv2.aruco.DetectorParameters()
+            self.detector = cv2.aruco.ArucoDetector(aruco_dictionary, parameters)
 
 
 
@@ -140,7 +140,12 @@ class ArucoNode(rclpy.node.Node):
 
         markers.header.stamp = self.get_clock().now().to_msg()
 
-        corners, marker_ids, rejected = self.detector.detectMarkers(cv_image)
+        if cv2.__version__ < "4.7.0":
+            corners, marker_ids, rejected = cv2.aruco.detectMarkers(
+                cv_image, self.aruco_dictionary, parameters=self.aruco_parameters
+            )
+        else:
+            corners, marker_ids, rejected = self.detector.detectMarkers(cv_image)
 
         if marker_ids is not None:
             # rvecs, tvecs, _ = cv2.aruco.estimatePoseSingleMarkers(

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
@@ -13,7 +13,7 @@ Parameters:
     marker_size - size of the markers in meters (default .0625)
     aruco_dictionary_id - dictionary that was used to generate markers
                           (default DICT_5X5_250)
-    poll_delay - how many seconds to wait between captures
+    poll_delay_seconds - how many seconds to wait between captures
     camera_index - which camera index to open
     camera_destination_index - If present, will attempt to use v4l2loopback 
                                 to allow another process to access the camera.
@@ -61,7 +61,7 @@ class ArucoNode(rclpy.node.Node):
         )
 
         self.declare_parameter(
-            name="poll_delay",
+            name="poll_delay_seconds",
             value=0.1,
             descriptor=ParameterDescriptor(
                 type=ParameterType.PARAMETER_DOUBLE,
@@ -111,10 +111,10 @@ class ArucoNode(rclpy.node.Node):
         )
         self.get_logger().info(f"Marker type: {dictionary_id_name}")
 
-        poll_delay = (
-            self.get_parameter("poll_delay").get_parameter_value().double_value
+        poll_delay_seconds = (
+            self.get_parameter("poll_delay_seconds").get_parameter_value().double_value
         )
-        self.get_logger().info(f"Poll frequency: {poll_delay}")
+        self.get_logger().info(f"Poll frequency: {poll_delay_seconds}")
 
         self.camera_index = (
             self.get_parameter("camera_index").get_parameter_value().integer_value
@@ -155,7 +155,7 @@ class ArucoNode(rclpy.node.Node):
         self.markers_pub = self.create_publisher(ArucoMarkers, "aruco_markers", 10)
 
         # Setup timers for opening camera (to allow easy retry) and for detecting aruco tags
-        self.detect_timer = self.create_timer(poll_delay, self.image_callback)
+        self.detect_timer = self.create_timer(poll_delay_seconds, self.image_callback)
         self.open_video_timer = self.create_timer(1.0, self.cam_callback)
 
         if cv2.__version__ < "4.7.0":

--- a/src/sil/package.xml
+++ b/src/sil/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
+  <depend>navigation2</depend>
   <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/src/wheels_controller/package.xml
+++ b/src/wheels_controller/package.xml
@@ -12,6 +12,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <depend>navigation2</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
This addresses issues in space-concordia-robotics/robotics-prototype#627 and space-concordia-robotics/robotics-prototype#626.
The following tasks have been completed:
- Aruco_node now opens a camera stream directly with opencv to perform detection.
- With the camera_destination_index parameter, can send camera stream to another device to that many processes can access it. There are dependencies that must be manually installed (as of now, may be doable with rosdep).

What's left:

- [ ] Finish pose detection (angles not working)
- [ ] Integration with robot.py launch file(?)