### PR TITLE
Make Aruco poses fully work and report angle values

### DIFF
--- a/src/ros2_aruco/README.md
+++ b/src/ros2_aruco/README.md
@@ -24,6 +24,12 @@ Parameters:
 * `camera_destination_index` - If present, will attempt to use v4l2loopback 
                                 to allow another process to access the camera.
                                 Needs ffmpeg and v4l2loopback-dev installed.
+* `calibration_resolution` - At which resolution the camera was calibrated. 
+                             Used to scale the pixel values if doesn't match 
+                             current capture resolution.
+* `capture_resolution` - Desired resolution to open the camera stream at.
+* `camera_matrix` - Array corresponding to the 3x3 camera's intrinsic matrix K
+* `distortion_coefficients` - Array of distortion coefficients
 
 ## Running Marker Detection
 

--- a/src/ros2_aruco/README.md
+++ b/src/ros2_aruco/README.md
@@ -36,6 +36,25 @@ ros2 launch ros2_aruco aruco_recognition.launch.py
 ros2 run ros2_aruco aruco_node
 ```
 
+### Getting Marker Poses
+To know where the actual markers are in 3D space relative to the camera, the camera
+must be calibrated, and the size of the markers must be known. The following steps
+explain how to set it up:
+
+1. Get some way to publish a camera to a ROS topic.
+One way is installing v4l2_camera with sudo apt-get install ros-${ROS_DISTRO}-v4l2-camera, then 
+run with a command such as `ros2 run v4l2_camera v4l2_camera_node --ros-args -p video_device:="/dev/video2" -p image_size:=[1920,1080]`.
+Check the **video_device** argument, to ensure the correct webcam is being accessed. Rviz2 can visualize them with an Image view.
+2. Calibrate the camera. Install the `camera_calibration` ros package, then run it. More info is [here](https://docs.ros.org/en/rolling/p/camera_calibration/).
+A command such as `ros2 run camera_calibration cameracalibrator --size 8x6 --square 0.020 image:=/image_raw` will work, ensure
+the checkerboard used (eg [here](https://markhedleyjones.com/projects/calibration-checkerboard-collection)) is the right size and 
+**square size**. The **size** is the number of corners in the checkerboard, the **square size** is the width of each square (in m). 
+3. Move the camera around the checkerboard to calibrate (it should show dots and lines overlaid on the image)
+4. Click "calibrate"
+5. Click "save" and open the calibration at /tmp/calibrationdata.tar.gz
+6. Paste the "camera_matrix" and "distortion_coefficients" into aruco_parameters.yaml
+7. Set the "marker_size" to the marker width (in m)
+
 ## Generating Marker Images
 
 ```

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -1,31 +1,32 @@
 /aruco_node:
   ros__parameters:
-    poll_delay_seconds: 0.1
+    poll_delay_seconds: 0.2
     marker_size: 0.050
     aruco_dictionary_id: "DICT_5X5_250"
     camera_index: 2
+    capture_resolution: [1920, 1080]
     # camera_destination_index: 10
-    # Data comes from the C920 in the lab (on the gripper), calibrated with an 8x6 grid.
-    camera_matrix: [642.97733,   0.     , 322.98653,
-                    0.     , 642.5178 , 230.41907,
-                    0.     ,   0.     ,   1.     ]
-    distortion_coefficients: [0.049779, -0.209170, -0.000231, 0.000367, 0.000000]
+    # Data comes from a C920 in the lab calibrated with an 8x6 grid.
+    camera_matrix: [1727.79073,    0.     , 1063.47911,
+                    0.     , 1768.42988,  733.47827,
+                    0.     ,    0.     ,    1.     ]
+    distortion_coefficients: [0.383893, -0.475512, 0.031456, 0.005959, 0.000000]
 
 # This was the complete set of calibration data:
-# image_width: 640
-# image_height: 480
+# image_width: 1920
+# image_height: 1080
 # camera_name: narrow_stereo
 # camera_matrix:
 #   rows: 3
 #   cols: 3
-#   data: [642.97733,   0.     , 322.98653,
-#            0.     , 642.5178 , 230.41907,
-#            0.     ,   0.     ,   1.     ]
+#   data: [1727.79073,    0.     , 1063.47911,
+#             0.     , 1768.42988,  733.47827,
+#             0.     ,    0.     ,    1.     ]
 # distortion_model: plumb_bob
 # distortion_coefficients:
 #   rows: 1
 #   cols: 5
-#   data: [0.049779, -0.209170, -0.000231, 0.000367, 0.000000]
+#   data: [0.383893, -0.475512, 0.031456, 0.005959, 0.000000]
 # rectification_matrix:
 #   rows: 3
 #   cols: 3
@@ -35,6 +36,6 @@
 # projection_matrix:
 #   rows: 3
 #   cols: 4
-#   data: [642.64434,   0.     , 323.26127,   0.     ,
-#            0.     , 644.34004, 230.33636,   0.     ,
-#            0.     ,   0.     ,   1.     ,   0.     ]
+#   data: [1865.86427,    0.     , 1066.75093,    0.     ,
+#             0.     , 1879.6054 ,  758.5378 ,    0.     ,
+#             0.     ,    0.     ,    1.     ,    0.     ]

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -6,26 +6,26 @@
     camera_index: 2
     # camera_destination_index: 10
     # Data comes from the C920 in the lab (on the gripper), calibrated with an 8x6 grid.
-    camera_matrix: [1431.3944 ,    0.     ,  890.65546,
-                    0.     , 1433.52778,  497.59295,
-                    0.     ,    0.     ,    1.     ]
-    distortion_coefficients: [0.058807, -0.181086, 0.002435, -0.003756, 0.000000]
+    camera_matrix: [642.97733,   0.     , 322.98653,
+                    0.     , 642.5178 , 230.41907,
+                    0.     ,   0.     ,   1.     ]
+    distortion_coefficients: [0.049779, -0.209170, -0.000231, 0.000367, 0.000000]
 
 # This was the complete set of calibration data:
-# image_width: 1920
-# image_height: 1080
+# image_width: 640
+# image_height: 480
 # camera_name: narrow_stereo
 # camera_matrix:
 #   rows: 3
 #   cols: 3
-#   data: [1431.3944 ,    0.     ,  890.65546,
-#             0.     , 1433.52778,  497.59295,
-#             0.     ,    0.     ,    1.     ]
+#   data: [642.97733,   0.     , 322.98653,
+#            0.     , 642.5178 , 230.41907,
+#            0.     ,   0.     ,   1.     ]
 # distortion_model: plumb_bob
 # distortion_coefficients:
 #   rows: 1
 #   cols: 5
-#   data: [0.058807, -0.181086, 0.002435, -0.003756, 0.000000]
+#   data: [0.049779, -0.209170, -0.000231, 0.000367, 0.000000]
 # rectification_matrix:
 #   rows: 3
 #   cols: 3
@@ -35,6 +35,6 @@
 # projection_matrix:
 #   rows: 3
 #   cols: 4
-#   data: [1408.47852,    0.     ,  873.88624,    0.     ,
-#             0.     , 1441.61267,  498.62912,    0.     ,
-#             0.     ,    0.     ,    1.     ,    0.     ]
+#   data: [642.64434,   0.     , 323.26127,   0.     ,
+#            0.     , 644.34004, 230.33636,   0.     ,
+#            0.     ,   0.     ,   1.     ,   0.     ]

--- a/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
+++ b/src/ros2_aruco/ros2_aruco/config/aruco_parameters.yaml
@@ -4,6 +4,7 @@
     marker_size: 0.050
     aruco_dictionary_id: "DICT_5X5_250"
     camera_index: 2
+    calibration_resolution: [1920, 1080]
     capture_resolution: [1920, 1080]
     # camera_destination_index: 10
     # Data comes from a C920 in the lab calibrated with an 8x6 grid.

--- a/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
+++ b/src/ros2_aruco/ros2_aruco/ros2_aruco/aruco_node.py
@@ -324,6 +324,7 @@ class ArucoNode(rclpy.node.Node):
         cv_image = frame
         markers = ArucoMarkers()
         pose_array = PoseArray()
+        pose_array.header.frame_id = 'base_link'
 
         markers.header.stamp = self.get_clock().now().to_msg()
 
@@ -348,14 +349,14 @@ class ArucoNode(rclpy.node.Node):
                     pose.position.y = tvecs[i][1][0]
                     pose.position.z = tvecs[i][2][0]
 
-                    # rot_matrix = np.eye(4)
-                    # rot_matrix[0:3, 0:3] = cv2.Rodrigues(np.array(rvecs))[0]
-                    # quat = tf_transformations.quaternion_from_matrix(rot_matrix)
+                    rot_matrix = np.eye(4)
+                    rot_matrix[0:3, 0:3] = cv2.Rodrigues(np.array(rvecs))[0]
+                    quat = tf_transformations.quaternion_from_matrix(rot_matrix)
 
-                    # pose.orientation.x = quat[0]
-                    # pose.orientation.y = quat[1]
-                    # pose.orientation.z = quat[2]
-                    # pose.orientation.w = quat[3]
+                    pose.orientation.x = quat[0]
+                    pose.orientation.y = quat[1]
+                    pose.orientation.z = quat[2]
+                    pose.orientation.w = quat[3]
 
                     pose_array.poses.append(pose)
                     markers.poses.append(pose)


### PR DESCRIPTION
The reason the pose detection was off is that the calibration resolution was different from the camera's resolution. Now, you can specify the desired resolution to open the camera in. In addition, a "calibration_resolution" is specifiable, so if the camera can't open in the correct resolution (for whatever reason) it will rescale the pixel values.

Also added documentation describing how to calibrate a camera.